### PR TITLE
[ADD] sync quantities of contracted vs distributed publications

### DIFF
--- a/publication/models/account_analytic_invoice_line.py
+++ b/publication/models/account_analytic_invoice_line.py
@@ -14,7 +14,7 @@ class AccountAnalyticInvoiceLine(models.Model):
         readonly=True)
     publication = fields.Boolean(
         string='Subscription product line',
-        related='product_id.publication',
+        related='product_id.product_tmpl_id.publication',
         store=True)
 
     @api.multi

--- a/publication/models/account_analytic_invoice_line.py
+++ b/publication/models/account_analytic_invoice_line.py
@@ -31,3 +31,41 @@ class AccountAnalyticInvoiceLine(models.Model):
         action['view_mode'] = 'form'
         action['target'] = 'current'
         return action
+
+    @api.model
+    def create(self, vals):
+        this = super(AccountAnalyticInvoiceLine, self).create(vals)
+        self.env['distribution.list']._update_contract_partner_copies(
+            this.product_id, this.analytic_account_id.partner_id,
+        )
+        return this
+
+    @api.multi
+    def write(self, vals):
+        old_values = set(self.mapped(
+            lambda x: (x.product_id, x.analytic_account_id.partner_id)
+        )) if 'product_id' in vals else []
+        result = super(AccountAnalyticInvoiceLine, self).write(vals)
+        needs_update = set(['product_id', 'quantity']) & set(vals.keys())
+        if needs_update:
+            for this in self:
+                self.env['distribution.list']._update_contract_partner_copies(
+                    this.product_id, this.analytic_account_id.partner_id,
+                )
+            for product, partner in old_values:
+                self.env['distribution.list']._update_contract_partner_copies(
+                    product, partner,
+                )
+        return result
+
+    @api.multi
+    def unlink(self):
+        updates = set(self.mapped(
+            lambda x: (x.product_id, x.analytic_account_id.partner_id)
+        ))
+        result = super(AccountAnalyticInvoiceLine, self).unlink()
+        for product, partner in updates:
+            self.env['distribution.list']._update_contract_partner_copies(
+                product, partner,
+            )
+        return result

--- a/publication/models/distribution_list.py
+++ b/publication/models/distribution_list.py
@@ -82,7 +82,7 @@ class DistributionList(models.Model):
         required=True)
     distribution_type = fields.Selection(
         string='Type of publication',
-        related='product_id.distribution_type',
+        related='product_id.product_tmpl_id.distribution_type',
         store=True)
     partner_id = fields.Many2one(
         comodel_name='res.partner',

--- a/publication/views/distribution_list.xml
+++ b/publication/views/distribution_list.xml
@@ -74,9 +74,18 @@
                         attrs="{'invisible': ['|',('product_id','=',False),('contract_partner_id','=',False)]}"
                         colspan="4" col="6"
                         >
-                        <field name="contract_count" />
-                        <field name="assigned_count" />
-                        <field name="available_count" />
+                        <field
+                            name="contract_count"
+                            attrs="{'invisible': [('distribution_type','=','email')]}"
+                        />
+                        <field
+                            name="assigned_count"
+                            attrs="{'invisible': [('distribution_type','=','email')]}"
+                        />
+                        <field
+                            name="available_count"
+                            attrs="{'invisible': [('distribution_type','=','email')]}"
+                        />
                         <field
                             name="partner_id"
                             options="{'no_create': true, 'no_create_edit': true}"

--- a/publication/views/product_template.xml
+++ b/publication/views/product_template.xml
@@ -8,7 +8,7 @@
         <field name="model">product.template</field>
         <field
             name="inherit_id"
-            ref="product.product_template_only_form_view"
+            ref="product.product_template_form_view"
             />
         <field name="type">form</field>
         <field


### PR DESCRIPTION
The relevant commit is ea095ee, the rest are improvements I propose that I came across while fiddling with this.

a3ca4b2 is a bit tricky: If you relate to the inherited field on `product.product`, Odoo won't update the stored field when you change the field value on the product template. Relating to the original field makes it work both on `product.product` and `product.template`. I still consider this a bug in related fields, but there's a won't fix in Odoo SA's issue tracker about this (citation needed)